### PR TITLE
Feature request: Add a function to create multiple data streams at once

### DIFF
--- a/examples/uptime.js
+++ b/examples/uptime.js
@@ -13,28 +13,33 @@ var m2xClient = new M2X(config.api_key);
 
 // Create the streams if they don't exist already
 source.update(function(data) {
-    m2xClient.devices.updateStream(config.device, "load_1m");
-    m2xClient.devices.updateStream(config.device, "load_5m");
-    m2xClient.devices.updateStream(config.device, "load_15m");
-});
+    var streams = ["load_1m", "load_5m", "load_15m"];
 
-// Retrieve values each 1100ms and post them to the device
-source.updateEvery(1100, function(data, stopLoop) {
-    var at = new Date().toISOString();
-    var values = {
-        load_1m:  [ { value: data.load_1m, timestamp: at } ],
-        load_5m:  [ { value: data.load_5m, timestamp: at } ],
-        load_15m: [ { value: data.load_15m, timestamp: at } ]
-    };
-
-    // Write the different values into AT&T M2X
-    m2xClient.devices.postMultiple(config.device, values, function(result) {
-        console.log(result);
-        if (result.isError()) {
-            // Stop the update loop if an error occurs.
-            stopLoop();
-
-            console.log(result.error());
+    m2xClient.devices.updateStreams(config.device, streams, function(response) {
+        // Retrieve values each 1100ms and post them to the device
+        if (response.isError()) {
+            console.log("Cannot create stream:", response);
+            return;
         }
+        source.updateEvery(1000, function(data, stopLoop) {
+            var at = new Date().toISOString();
+            var values = {
+                load_1m:  [ { value: data.load_1m, timestamp: at } ],
+                load_5m:  [ { value: data.load_5m, timestamp: at } ],
+                load_15m: [ { value: data.load_15m, timestamp: at } ]
+            };
+
+            // Write the different values into AT&T M2X
+            m2xClient.devices.postMultiple(config.device, values, function(result) {
+                console.log(result);
+                if (result.isError()) {
+                    // Stop the update loop if an error occurs.
+                    stopLoop();
+
+                    console.log(result.error());
+                }
+            });
+        });
     });
 });
+

--- a/examples/uptime.js
+++ b/examples/uptime.js
@@ -16,12 +16,13 @@ source.update(function(data) {
     var streams = ["load_1m", "load_5m", "load_15m"];
 
     m2xClient.devices.updateStreams(config.device, streams, function(response) {
-        // Retrieve values each 1100ms and post them to the device
         if (response.isError()) {
             console.log("Cannot create stream:", response);
             return;
         }
-        source.updateEvery(1000, function(data, stopLoop) {
+
+        // Retrieve values each 1100ms and post them to the device
+        source.updateEvery(1100, function(data, stopLoop) {
             var at = new Date().toISOString();
             var values = {
                 load_1m:  [ { value: data.load_1m, timestamp: at } ],

--- a/examples/uptime.js
+++ b/examples/uptime.js
@@ -11,10 +11,10 @@ var UptimeDataSource = require("./uptime_data_source");
 var source = new UptimeDataSource();
 var m2xClient = new M2X(config.api_key);
 
-// Create the streams if they don't exist already
 source.update(function(data) {
     var streams = ["load_1m", "load_5m", "load_15m"];
 
+    // Create the streams if they don't exist already
     m2xClient.devices.updateStreams(config.device, streams, function(response) {
         if (response.isError()) {
             console.log("Cannot create stream:", response);

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -103,17 +103,69 @@ Devices.prototype.streams = function(id, callback) {
 
 // Update stream's properties
 //
-// If the stream doesn't exist it will create it. See
-// https://m2x.att.com/developer/documentation/device#Create-Update-Data-Stream
-// for details.
+// If the stream doesn't exist it will create it.
 //
 // https://m2x.att.com/developer/documentation/v2/device#Create-Update-Data-Stream
 Devices.prototype.updateStream = function(id, name, params, callback) {
+    if (typeof params === "function") {
+        callback = params;
+        params = {};
+    }
+
     return this.client.put(
         helpers.url("/devices/%s/streams/%s", id, name),
         { params: params },
         callback
     );
+};
+
+// Update multiple streams
+//
+// The same stream properties will be used.
+//
+// names is a string array containing the stream names to be updated.
+//
+// Example usage:
+//
+//   devices.updateStreams(id, ["stream1", "stream2"], function(response, responses) {
+//      if (response.isError()) {
+//        console.log("It failed.");
+//      } else {
+//        console.log("Success!");
+//      }
+//      console.log("stream1 -> ", responses["stream1"]);
+//      console.log("stream2 -> ", responses["stream2"]);
+//   });
+//
+// The callback will receive response and responses, where:
+//   response is the last response. It can be used to indicate if the whole
+//            process was successful or not.
+//   responses is a map with the responses for each stream update.
+//
+// For properties details, see:
+// https://m2x.att.com/developer/documentation/v2/device#Create-Update-Data-Stream
+Devices.prototype.updateStreams = function(id, names, params, callback) {
+    if (typeof params === "function") {
+        callback = params;
+        params = {};
+    }
+
+    var self = this;
+    var updateNext = function(index, responses) {
+        var name = names[index];
+
+        self.updateStream(id, name, params, function(response) {
+            responses[name] = response;
+
+            if (response.isError() || index === 0) {
+                callback(response, responses);
+            } else {
+                updateNext(index - 1, responses);
+            }
+        });
+    };
+
+    updateNext(names.length - 1, {});
 };
 
 // Set the stream value


### PR DESCRIPTION
This allows easier flow handling when creating multiple streams. For example, error handling, or when the streams are required to exist to be able to continue.

The `uptime` example has also been changed to demonstrate this.