### PR TITLE
Handle empty responses to prevent uncaught exceptions

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -1,12 +1,13 @@
 "use strict";
 
 var Response = function(error, res) {
+    res = res || {};
     this.raw = res.body;
     this.headers = res.headers;
-    this.status = res.statusCode;
+    this.status = res.statusCode || 500;
 
     if (error) {
-        this._error = { error: res.body };
+        this._error = { error: (res.body || "Unknown error: empty response") };
     } else {
         if (res.headers["content-type"] === "application/json") {
             try {


### PR DESCRIPTION
Looks like the API returned a weird response which caused an empty [response object](https://github.com/attm2x/m2x-nodejs/blob/master/lib/client.js#L80) from [request](https://github.com/request/request)

Stacktrace:

```
May 05 14:50:44 : [debug] "2015-05-05T14:50:44.777Z"  'TOPIC [devices] ACTIONS [postMultiple]'
May 05 14:50:46 : 5 May 14:50:46 - [red] Uncaught Exception:
May 05 14:50:46 : 5 May 14:50:46 - TypeError: Cannot read property 'body' of undefined
May 05 14:50:46 : at new Response (/usr/local/lib/node_modules/breeze-core/node_modules/node-red-m2x/node_modules/m2x/lib/response.js:4:19)
May 05 14:50:46 : at Request._callback (/usr/local/lib/node_modules/breeze-core/node_modules/node-red-m2x/node_modules/m2x/lib/client.js:80:33)
May 05 14:50:46 : at self.callback (/usr/local/lib/node_modules/breeze-core/node_modules/request/request.js:373:22)
May 05 14:50:46 : at Request.emit (events.js:95:17)
May 05 14:50:46 : at Request.onRequestError (/usr/local/lib/node_modules/breeze-core/node_modules/request/request.js:971:8)
May 05 14:50:46 : at ClientRequest.emit (events.js:95:17)
May 05 14:50:46 : at CleartextStream.socketErrorListener (http.js:1552:9)
May 05 14:50:46 : at CleartextStream.emit (events.js:95:17)
May 05 14:50:46 : at Socket.onerror (tls.js:1456:17)
May 05 14:50:46 : at Socket.emit (events.js:117:20)
```