### PR TITLE
Feature: Post device update

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -359,6 +359,42 @@ Devices.prototype.postUpdates = function(id, params, callback) {
     }, callback);
 };
 
+// Post Device Update (Single Value to Multiple Streams)
+//
+// This method allows posting a single value to multiple streams
+// belonging to a device and optionally, the device's location.
+//
+// All the streams should be created before posting values using this method.
+//
+// The `params` parameter accepts an object which can contain the following keys:
+//   - values:    An Object in which the keys are the stream names and the values
+//                hold the stream values.
+//   - location:  (optional) A hash with the current location of the specified
+//                device.
+//   - timestamp: (optional) The timestamp for all the passed values and
+//                location. If ommited, the M2X server's time will be used.
+//
+//      {
+//          values: {
+//              temperature: 30,
+//              humidity:    80
+//          },
+//          location: {
+//              name:      "Storage Room",
+//              latitude:  -37.9788423562422,
+//              longitude: -57.5478776916862,
+//              elevation: 5
+//         }
+//      }
+//
+// https://m2x.att.com/developer/documentation/v2/device#Post-Device-Update--Single-Values-to-Multiple-Streams-
+Devices.prototype.postUpdate = function(id, params, callback) {
+    return this.client.post(helpers.url("/devices/%s/update", id), {
+        headers: { "Content-Type": "application/json" },
+        params:  params
+    }, callback);
+};
+
 // Return a list of access log to the supplied device
 //
 // https://m2x.att.com/developer/documentation/v2/device#View-Request-Log


### PR DESCRIPTION
This PR Adds support for the `POST /devices/:id/update` endpoint