### PR TITLE
Avoid strict parsing of Content-Type header

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -9,7 +9,7 @@ var Response = function(error, res) {
     if (error) {
         this._error = { error: (res.body || "Unknown error: empty response") };
     } else {
-        if (res.headers["content-type"] === "application/json") {
+        if (res.headers["content-type"].includes("application/json")) {
             try {
                 this.json = res.body ? JSON.parse(res.body) : {};
             } catch (ex) {


### PR DESCRIPTION
Recently, the M2X API extended the Content Type header of its responses in order to include the charset.

This caused this and some other client libraries to break because they do a strict assertion on the content of such header and fail to parse JSON properly.